### PR TITLE
hide fixed navbar when main navbar is still visible

### DIFF
--- a/app/assets/javascripts/app/navbar.js
+++ b/app/assets/javascripts/app/navbar.js
@@ -16,7 +16,7 @@
 
   function handleNavbar() {
     var st = $(window).scrollTop();
-    if(st > lastScrollTop) {
+    if((st > lastScrollTop) && (st > 150)) {
       headerFixed.addClass('is-active');
       dropDown.removeClass('open');
     } else {


### PR DESCRIPTION
D'ailleurs @ssaunier ce code n'est pas suffisant car j'ai l'impression que le `window.scroll` est appelé toutes les X milliseconds.. Du coup quand tu scroll vers le haut de page très vite, t'as les deux navbars (fixed et  pas fixed) qui sont superposées. C'est pas trèèèèèèès grave mais pas très joli non plus..