### PR TITLE
Project card link fix

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -9,7 +9,7 @@
   box-shadow: 1px 1px 3px #E7E5E5;
   max-width: 380px;
   margin: auto;
-
+  position: relative;
   &:hover {
     .project-item-maker {
       transform: translate(0);
@@ -34,6 +34,14 @@
       }
     }
   }
+}
+
+.card-city-link {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  z-index: 4;
 }
 
 .card-city-teachers {

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -10,7 +10,10 @@
   max-width: 380px;
   margin: auto;
   position: relative;
+
   &:hover {
+    opacity: .9;
+
     .project-item-maker {
       transform: translate(0);
     }

--- a/app/assets/stylesheets/components/_project_item.scss
+++ b/app/assets/stylesheets/components/_project_item.scss
@@ -24,6 +24,14 @@
     height: 35px;
   }
 
+  &:hover {
+    opacity: .9;
+
+    .project-item-maker {
+      transform: translateX(0);
+    }
+  }
+
   &-container {
     display: flex;
     flex: 0 0 33%;
@@ -43,24 +51,7 @@
     opacity: 1;
     padding: 10px;
     position: relative;
-
-    &:hover {
-      opacity: .9;
-
-      .project-item-makers {
-        background: rgba(255, 255, 255, 0.7);
-
-      }
-
-      .project-item-maker {
-        transform: translateX(0);
-      }
-    }
   }
-
-  // &:hover {
-  //   background: #f7f7fa;
-  // }
 }
 
 .project-item-url {

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -66,7 +66,6 @@
       <% projects.each do |project| %>
        <% project = OpenStruct.new project %>
         <div class="project-item-container">
-          <a class='project-item-url' target='_blank' href=<%= project.url %>></a>
           <div class="project-item">
             <div class='project-item-head'>
               <div class="project-thumbnail" style="background: url(<%= project.card %>);background-size:cover;background-position:center center;">
@@ -93,6 +92,8 @@
                 <% end %>
               </div>
             </div>
+            <a class='project-item-url' target='_blank' href=<%= project.url %>></a>
+
           </div>
         </div>
       <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -31,7 +31,6 @@
 
 <%= render partial: "shared/testimonials" %>
 
-
 <% cache [ 'stories', locale ] do %>
   <% stories = @client.random_stories(limit: 2, excluded_ids: (session[:story_ids] || [])) %>
   <%= react_component 'Stories', {

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -121,8 +121,8 @@
     <div class="card-cities">
       <% @cities.each do |city| %>
         <div class="card-city-container">
-          <%= link_to city_path(city: city["slug"]) do %>
             <div class="card-city">
+              <%= link_to "", city_path(city: city["slug"]), class: "card-city-link" %>
               <div class="card-city-header" style="background-image: url('<%= cl_image_path city['city_background_picture_path'] || "", height: 200, crop: :fill %>')">
               <span class="card-city-filter"></span>
               </div>
@@ -139,7 +139,6 @@
                 </div>
               </div>
             </div>
-          <% end %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Moved the `project-item-url` into `project-item` so that the padding from the container doesn't affect the link

Created a `.card-city-link` for the `card-city` instead of wrapping the whole card in a `<%= link to do `