### PR TITLE
Overlap citycard fix

### DIFF
--- a/app/assets/stylesheets/components/_project_item.scss
+++ b/app/assets/stylesheets/components/_project_item.scss
@@ -112,7 +112,7 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 1;
+  z-index: 5;
   bottom: 0;
   margin: auto;
   transition: background 0.3s ease;

--- a/app/assets/stylesheets/components/_project_item.scss
+++ b/app/assets/stylesheets/components/_project_item.scss
@@ -112,7 +112,7 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 99;
+  z-index: 1;
   bottom: 0;
   margin: auto;
   transition: background 0.3s ease;


### PR DESCRIPTION
the z-index of avatars was way too high (99) and the alerts were 11:

![screen shot 2017-07-24 at 09 43 29](https://user-images.githubusercontent.com/16685604/28515451-9744877a-7055-11e7-91ee-36a647b46e39.png)

Now looks like this and the over effect still works

![screen shot 2017-07-24 at 09 49 30](https://user-images.githubusercontent.com/16685604/28515463-a5252e08-7055-11e7-93ed-bfc63c8c77aa.png)
