### PR TITLE
prevent marketing content to crash style

### DIFF
--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -59,7 +59,9 @@
     <div class="container">
       <div class="row">
         <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          <%= markdown(@city.marketing_specifics) %>
+          <marketing>
+            <%= markdown(@city.marketing_specifics) %>
+          </marketing>
         </div>
       </div>
     </div>
@@ -187,7 +189,9 @@
       </h2>
       <div class="row">
         <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          <%= markdown(@city.logistic_specifics) %>
+          <logistic>
+            <%= markdown(@city.logistic_specifics) %>
+          </logistic>
         </div>
       </div>
     </div>


### PR DESCRIPTION
@ssaunier this is a suggestion, adding very specific tag around markdown content could help preventing whole HTML page structure to be crashed 