### PR TITLE
Use the slack attachment format for hiring channel message

### DIFF
--- a/app/controllers/employer_prospects_controller.rb
+++ b/app/controllers/employer_prospects_controller.rb
@@ -21,9 +21,51 @@ class EmployerProspectsController < ApplicationController
   def notify_slack(employer)
     NotifySlack.perform_later(
       "channel": Rails.env.development? ? "test" : "hiring",
-      "username": "www",
+      "username": "Employer Prospect",
       "icon_url": "https://raw.githubusercontent.com/lewagon/mooc-images/master/slack_bot.png",
-      "text": employer.to_slack_message
+      "attachments": [
+        "color": "#2980b9",
+        "attachment_type": "default",
+        "fallback": "New Employer Prospect (#{employer.company})",
+        "fields": [
+          {
+            "title": "Name",
+            "value": employer.full_name,
+          },
+          {
+            "title": "Phone number",
+            "value": employer.phone_number,
+            "short": true
+          },
+          {
+            "title": "Email",
+            "value": employer.email,
+            "short": true
+          },
+          {
+            "title": "Company",
+            "value": employer.company,
+            "short": true
+          },
+          {
+            "title": "Website",
+            "value": employer.website,
+            "short": true
+          },
+          {
+            "title": "Why",
+            "value": employer.message,
+          },
+          {
+            "title": "Which cities",
+            "value": employer.locations.join(", ")
+          },
+          {
+            "title": "Looking for",
+            "value": employer.targets.join(", ")
+          }
+        ]
+      ]
     )
   end
 

--- a/app/models/employer_prospect.rb
+++ b/app/models/employer_prospect.rb
@@ -26,12 +26,4 @@ class EmployerProspect < ApplicationRecord
     "#{first_name.capitalize} #{last_name.capitalize}"
   end
 
-  def to_slack_message
-"*Person:* #{full_name} - #{email} - #{phone_number}
-*Company:* #{company}
-*Company Website:* #{website}
-*Why:* #{message}
-*Which city:* #{self.locations.reject { |l| l.empty? }.join(", ")}
-*Looking for:* #{self.targets.reject { |l| l.empty? }.join(", ")}"
-  end
 end

--- a/spec/models/employer_prospect_spec.rb
+++ b/spec/models/employer_prospect_spec.rb
@@ -64,12 +64,4 @@ RSpec.describe EmployerProspect, type: :model do
       expect(employer.full_name).to eq("George Abitbol")
     end
   end
-
-  describe "#to_slack_message" do
-    it 'returns a formated text' do
-      message = employer.to_slack_message
-      expect(message).to match(/George/)
-      expect(message).to match(/\*Company\:\*/)
-    end
-  end
 end


### PR DESCRIPTION
This PR introduce Attachment content formating for the Hiring channel on Slack.
Documentation: https://api.slack.com/docs/message-attachments
