### PR TITLE
[READY] Employer Prospects messages index for drivers

### DIFF
--- a/app/assets/stylesheets/pages/_employers.scss
+++ b/app/assets/stylesheets/pages/_employers.scss
@@ -206,3 +206,14 @@ $scale: 1.07;
     }
   }
 }
+
+
+.employer-table-list {
+  li {
+    margin-bottom: 3px;
+  }
+}
+
+.table-employer {
+  font-size: 14px;
+}

--- a/app/assets/stylesheets/pages/_employers.scss
+++ b/app/assets/stylesheets/pages/_employers.scss
@@ -218,45 +218,28 @@ $scale: 1.07;
   font-size: 14px;
 }
 
-.employer-card {
-  background: white;
-  border-radius: 3px;
-  box-shadow: 1px 1px 3px #E7E5E5;
-  margin: 5px 0;
-  padding: 5px 10px;
+.employer-card-body {
   display: flex;
-  flex-wrap: wrap;
-  strong {
-    color: #A9A9A9
-  }
-  ul {
-    margin-bottom: 0;
-  }
-  .employer-card-details {
-    @media (min-width: 768px) {
-      flex: 30%;
-    }
-    display: flex;
-  }
-  .employer-card-targets {
-    @media (min-width: 768px) {
-      flex: 30%;
-    }
-    display: flex;
-  }
-  .employer-card-message {
-    height: 150px;
-    @media (min-width: 768px) {
-      flex: 40%;
-    }
-    overflow: auto;
-  }
+}
 
-  .employer-data {
-    color: #555555;
-  }
+.employer-card-details {
+  flex: 40%;
+}
+
+.employer-card-message {
+  flex: 60%;
+  overflow: auto;
+  height: 125px;
 }
 
 #employer_prospects_index {
   background: #F4F4F4;
+}
+
+.employer-prospect-header {
+  h2 {
+    margin-bottom: 20px;
+  }
+  margin-top: 20px;
+  margin-bottom: 40px;
 }

--- a/app/assets/stylesheets/pages/_employers.scss
+++ b/app/assets/stylesheets/pages/_employers.scss
@@ -217,3 +217,46 @@ $scale: 1.07;
 .table-employer {
   font-size: 14px;
 }
+
+.employer-card {
+  background: white;
+  border-radius: 3px;
+  box-shadow: 1px 1px 3px #E7E5E5;
+  margin: 5px 0;
+  padding: 5px 10px;
+  display: flex;
+  flex-wrap: wrap;
+  strong {
+    color: #A9A9A9
+  }
+  ul {
+    margin-bottom: 0;
+  }
+  .employer-card-details {
+    @media (min-width: 768px) {
+      flex: 30%;
+    }
+    display: flex;
+  }
+  .employer-card-targets {
+    @media (min-width: 768px) {
+      flex: 30%;
+    }
+    display: flex;
+  }
+  .employer-card-message {
+    height: 150px;
+    @media (min-width: 768px) {
+      flex: 40%;
+    }
+    overflow: auto;
+  }
+
+  .employer-data {
+    color: #555555;
+  }
+}
+
+#employer_prospects_index {
+  background: #F4F4F4;
+}

--- a/app/assets/stylesheets/pages/_employers.scss
+++ b/app/assets/stylesheets/pages/_employers.scss
@@ -233,6 +233,7 @@ $scale: 1.07;
 }
 
 #employer_prospects_index {
+  min-height: 100vh;
   background: #F4F4F4;
 }
 

--- a/app/controllers/employer_prospects_controller.rb
+++ b/app/controllers/employer_prospects_controller.rb
@@ -1,6 +1,6 @@
 class EmployerProspectsController < ApplicationController
   http_basic_authenticate_with name: ENV['EMPLOYER_PROSPECTS_USERNAME'], password: ENV['EMPLOYER_PROSPECTS_SECRET'], only: :index
-
+  layout 'back_office'
   def index
     if params[:city] && params[:city] != ''
       @employers = EmployerProspect.where("? = ANY (locations)", params[:city])

--- a/app/controllers/employer_prospects_controller.rb
+++ b/app/controllers/employer_prospects_controller.rb
@@ -2,7 +2,7 @@ class EmployerProspectsController < ApplicationController
   http_basic_authenticate_with name: ENV['EMPLOYER_PROSPECTS_USERNAME'], password: ENV['EMPLOYER_PROSPECTS_SECRET'], only: :index
 
   def index
-    if params[:city]
+    if params[:city] && params[:city] != ''
       @employers = EmployerProspect.where("? = ANY (locations)", params[:city])
     else
       @employers = EmployerProspect.all

--- a/app/controllers/employer_prospects_controller.rb
+++ b/app/controllers/employer_prospects_controller.rb
@@ -2,7 +2,11 @@ class EmployerProspectsController < ApplicationController
   http_basic_authenticate_with name: ENV['EMPLOYER_PROSPECTS_USERNAME'], password: ENV['EMPLOYER_PROSPECTS_SECRET'], only: :index
 
   def index
-    @employers = EmployerProspect.all
+    if params[:location]
+      @employers = EmployerProspect.where("? = ANY (locations)", params[:location])
+    else
+      @employers = EmployerProspect.all
+    end
   end
 
   def create

--- a/app/controllers/employer_prospects_controller.rb
+++ b/app/controllers/employer_prospects_controller.rb
@@ -2,8 +2,8 @@ class EmployerProspectsController < ApplicationController
   http_basic_authenticate_with name: ENV['EMPLOYER_PROSPECTS_USERNAME'], password: ENV['EMPLOYER_PROSPECTS_SECRET'], only: :index
 
   def index
-    if params[:location]
-      @employers = EmployerProspect.where("? = ANY (locations)", params[:location])
+    if params[:city]
+      @employers = EmployerProspect.where("? = ANY (locations)", params[:city])
     else
       @employers = EmployerProspect.all
     end

--- a/app/controllers/employer_prospects_controller.rb
+++ b/app/controllers/employer_prospects_controller.rb
@@ -1,4 +1,5 @@
 class EmployerProspectsController < ApplicationController
+  http_basic_authenticate_with name: ENV['EMPLOYER_PROSPECTS_USERNAME'], password: ENV['EMPLOYER_PROSPECTS_SECRET'], only: :index
 
   def index
     @employers = EmployerProspect.all

--- a/app/controllers/employer_prospects_controller.rb
+++ b/app/controllers/employer_prospects_controller.rb
@@ -1,5 +1,9 @@
 class EmployerProspectsController < ApplicationController
 
+  def index
+    @employers = EmployerProspect.all
+  end
+
   def create
     @employer = EmployerProspect.new(employer_prospect_params)
     respond_to do |format|

--- a/app/models/employer_prospect.rb
+++ b/app/models/employer_prospect.rb
@@ -22,8 +22,15 @@ class EmployerProspect < ApplicationRecord
   validates :email, format: /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
   validates :website, format: /\A(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?\z/
 
+  before_validation :sanitize_url
+
   def full_name
     "#{first_name.capitalize} #{last_name.capitalize}"
+  end
+
+  def sanitize_url
+    url.strip!
+    url = "http://" + url unless url.start_with?("http", "https")
   end
 
 end

--- a/app/views/employer_prospects/index.html.erb
+++ b/app/views/employer_prospects/index.html.erb
@@ -1,53 +1,89 @@
-<div class="container-fluid">
-  <h2 class="text-center">Employer Prospects</h2>
-  <div class="table-responsive">
-    <table class="table table-hover table-condensed table-striped table-employer">
-      <thead class="thead-dark">
-        <tr>
-          <th scope="col">id</th>
-          <th scope="col">First Name</th>
-          <th scope="col">Last Name</th>
-          <th scope="col">Email</th>
-          <th scope="col">Phone Number</th>
-          <th scope="col">Company</th>
-          <th scope="col">Website</th>
-          <th scope="col">Targets</th>
-          <th scope="col">Locations</th>
-          <th scope="col">Message</th>
-          <th scope="col">Created At</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @employers.each do |employer| %>
+<div id="employer_prospects_index">
+  <div class="container">
+    <h2 class="text-center">Employer Prospects</h2>
+    <div class="row">
+      <% @employers.each do |employer| %>
+        <div class="col-xs-12">
+          <div class="employer-card">
+            <div class="employer-card-details">
+              <ul class="list-unstyled">
+                <li><strong>First Name:</strong> <span class="employer-data"><%= employer.first_name %></span> </li>
+                <li><strong>Last Name:</strong> <span class="employer-data"><%= employer.last_name %></span> </li>
+                <li><strong>Email:</strong> <span class="employer-data"><%= mail_to employer.email, employer.email, target: "_blank" %></span> </li>
+                <li><strong>Phone number:</strong> <span class="employer-data"><%= employer.phone_number %></span> </li>
+                <li><strong>Company:</strong> <span class="employer-data"><%= employer.company %></span> </li>
+                <li><strong>Website:</strong> <span class="employer-data"><%= link_to employer.website, employer.website, target: "_blank" %></span> </li>
+              </ul>
+            </div>
+            <div class="employer-card-targets">
+              <ul class="list-unstyled">
+                <li><strong>Targets:</strong> <span class="employer-data"><%= employer.targets.join(", ") %></span> </li>
+                <li><strong>Locations:</strong>
+                    <% employer.locations.each do |location| %>
+                      <span class="label label-primary"><%= location %></span>
+                    <% end %>
+                </li>
+              </ul>
+            </div>
+            <div class="employer-card-message">
+              <p>
+                <span><strong>Message:</strong></span>
+                <span class="employer-data"><%= employer.message %></span>
+              </p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-hover table-condensed table-striped table-employer">
+        <thead class="thead-dark">
           <tr>
-            <th scope="row"><%= employer.id %></th>
-            <td><%= employer.first_name %></td>
-            <td><%= employer.last_name %></td>
-
-            <td class="employer-table-break"><%= mail_to employer.email, employer.email, target: "_blank" %></td>
-            <td><%= employer.phone_number %></td>
-            <td class="employer-table-break"><%= employer.company %></td>
-            <td class="employer-table-break"><%= link_to employer.website, employer.website, target: "_blank" %></td>
-            <td class="employer-table-list"><%# employer.targets.join(", ") %>
-              <ul class="list-unstyled">
-                <% employer.targets.each do |target| %>
-                  <li><%= target %></li>
-                <% end %>
-              </ul>
-            </td>
-            <td class="employer-table-list">
-              <ul class="list-unstyled">
-                <% employer.locations.each do |location| %>
-                  <li><%= location %></li>
-                <% end %>
-              </ul>
-            </td>
-            <td><%= employer.message %></td>
-            <td><%= employer.created_at.strftime("%Y-%m-%d %H:%M %Z") %></td>
+            <th scope="col">id</th>
+            <th scope="col">First Name</th>
+            <th scope="col">Last Name</th>
+            <th scope="col">Email</th>
+            <th scope="col">Phone Number</th>
+            <th scope="col">Company</th>
+            <th scope="col">Website</th>
+            <th scope="col">Targets</th>
+            <th scope="col">Locations</th>
+            <th scope="col">Message</th>
+            <th scope="col">Created At</th>
           </tr>
-        <% end %>
+        </thead>
+        <tbody>
+          <% @employers.each do |employer| %>
+            <tr>
+              <th scope="row"><%= employer.id %></th>
+              <td><%= employer.first_name %></td>
+              <td><%= employer.last_name %></td>
 
-      </tbody>
-    </table>
+              <td class="employer-table-break"><%= mail_to employer.email, employer.email, target: "_blank" %></td>
+              <td><%= employer.phone_number %></td>
+              <td class="employer-table-break"><%= employer.company %></td>
+              <td class="employer-table-break"><%= link_to employer.website, employer.website, target: "_blank" %></td>
+              <td class="employer-table-list"><%# employer.targets.join(", ") %>
+                <ul class="list-unstyled">
+                  <% employer.targets.each do |target| %>
+                    <li><%= target %></li>
+                  <% end %>
+                </ul>
+              </td>
+              <td class="employer-table-list">
+                <ul class="list-unstyled">
+                  <% employer.locations.each do |location| %>
+                    <li><%= location %></li>
+                  <% end %>
+                </ul>
+              </td>
+              <td><%= employer.message %></td>
+              <td><%= employer.created_at.strftime("%Y-%m-%d %H:%M %Z") %></td>
+            </tr>
+          <% end %>
+
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/views/employer_prospects/index.html.erb
+++ b/app/views/employer_prospects/index.html.erb
@@ -23,10 +23,11 @@
             <th scope="row"><%= employer.id %></th>
             <td><%= employer.first_name %></td>
             <td><%= employer.last_name %></td>
-            <td><%= employer.email %></td>
+
+            <td class="employer-table-break"><%= mail_to employer.email, employer.email, target: "_blank" %></td>
             <td><%= employer.phone_number %></td>
-            <td><%= employer.company %></td>
-            <td><%= employer.website %></td>
+            <td class="employer-table-break"><%= employer.company %></td>
+            <td class="employer-table-break"><%= link_to employer.website, employer.website, target: "_blank" %></td>
             <td class="employer-table-list"><%# employer.targets.join(", ") %>
               <ul class="list-unstyled">
                 <% employer.targets.each do |target| %>

--- a/app/views/employer_prospects/index.html.erb
+++ b/app/views/employer_prospects/index.html.erb
@@ -1,30 +1,40 @@
 <div id="employer_prospects_index">
   <div class="container">
-    <h2 class="text-center">Employer Prospects</h2>
-    <div class="employer-index-filter text-center">
-      <%= form_tag "/employer_prospects", method: "get", class: "form-inline" do %>
-        <div class="form-group">
-          <%= label_tag :city, "Filter by location:" %>
-          <%= select_tag :city, options_for_select(@cities.map {|city| [city.name, city.slug]}, params[:city]), class: "form-control" %>
-        </div>
-        <%= submit_tag "Search", class: "btn btn-default" %>
-      <% end %>
-    </div>
+    <header class="employer-prospect-header">
+      <h2 class="text-center">Employer Prospects</h2>
+      <div class="employer-index-filter text-center">
+        <%= form_tag "/employer_prospects", method: "get", class: "form-inline" do %>
+          <div class="form-group">
+            <%= label_tag :city, "Filter by location:" %>
+            <%= select_tag :city, options_for_select(@cities.map {|city| [city.name, city.slug]}, params[:city]), prompt: "All cities", class: "form-control" %>
+          </div>
+          <%= submit_tag "Search", class: "btn btn-default" %>
+        <% end %>
+      </div>
+    </header>
     <div class="row">
       <% @employers.each do |employer| %>
         <div class="col-xs-12">
-          <div class="employer-card">
-            <div class="employer-card-details">
-              <ul class="list-unstyled">
-                <li><strong>First Name:</strong> <span class="employer-data"><%= employer.first_name %></span> </li>
-                <li><strong>Last Name:</strong> <span class="employer-data"><%= employer.last_name %></span> </li>
-                <li><strong>Email:</strong> <span class="employer-data"><%= mail_to employer.email, employer.email, target: "_blank" %></span> </li>
-                <li><strong>Phone number:</strong> <span class="employer-data"><%= employer.phone_number %></span> </li>
-                <li><strong>Company:</strong> <span class="employer-data"><%= employer.company %></span> </li>
-                <li><strong>Website:</strong> <span class="employer-data"><%= link_to employer.website, employer.website, target: "_blank" %></span> </li>
-              </ul>
+          <div class="panel panel-primary employer-card">
+            <div class="panel-heading"><%= employer.company %></div>
+            <div class="panel-body employer-card-body">
+              <div class="employer-card-details">
+                <ul class="list-unstyled">
+                  <li><strong>First Name:</strong> <span class="employer-data"><%= employer.first_name %></span> </li>
+                  <li><strong>Last Name:</strong> <span class="employer-data"><%= employer.last_name %></span> </li>
+                  <li><strong>Email:</strong> <span class="employer-data"><%= mail_to employer.email, employer.email, target: "_blank" %></span> </li>
+                  <li><strong>Phone number:</strong> <span class="employer-data"><%= employer.phone_number %></span> </li>
+                  <li><strong>Website:</strong> <span class="employer-data"><%= link_to employer.website, employer.website, target: "_blank" %></span> </li>
+                </ul>
+              </div>
+              <div class="employer-card-message">
+                <p>
+                  <span><strong>Message:</strong></span>
+                  <span class="employer-data"><%= employer.message %></span>
+                </p>
+              </div>
             </div>
-            <div class="employer-card-targets">
+            <div class="panel-footer">
               <ul class="list-unstyled">
                 <li><strong>Targets:</strong> <span class="employer-data"><%= employer.targets.join(", ") %></span> </li>
                 <li><strong>Locations:</strong>
@@ -34,65 +44,9 @@
                 </li>
               </ul>
             </div>
-            <div class="employer-card-message">
-              <p>
-                <span><strong>Message:</strong></span>
-                <span class="employer-data"><%= employer.message %></span>
-              </p>
-            </div>
           </div>
         </div>
       <% end %>
-    </div>
-    <div class="table-responsive">
-      <table class="table table-hover table-condensed table-striped table-employer">
-        <thead class="thead-dark">
-          <tr>
-            <th scope="col">id</th>
-            <th scope="col">First Name</th>
-            <th scope="col">Last Name</th>
-            <th scope="col">Email</th>
-            <th scope="col">Phone Number</th>
-            <th scope="col">Company</th>
-            <th scope="col">Website</th>
-            <th scope="col">Targets</th>
-            <th scope="col">Locations</th>
-            <th scope="col">Message</th>
-            <th scope="col">Created At</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @employers.each do |employer| %>
-            <tr>
-              <th scope="row"><%= employer.id %></th>
-              <td><%= employer.first_name %></td>
-              <td><%= employer.last_name %></td>
-
-              <td class="employer-table-break"><%= mail_to employer.email, employer.email, target: "_blank" %></td>
-              <td><%= employer.phone_number %></td>
-              <td class="employer-table-break"><%= employer.company %></td>
-              <td class="employer-table-break"><%= link_to employer.website, employer.website, target: "_blank" %></td>
-              <td class="employer-table-list"><%# employer.targets.join(", ") %>
-                <ul class="list-unstyled">
-                  <% employer.targets.each do |target| %>
-                    <li><%= target %></li>
-                  <% end %>
-                </ul>
-              </td>
-              <td class="employer-table-list">
-                <ul class="list-unstyled">
-                  <% employer.locations.each do |location| %>
-                    <li><%= location %></li>
-                  <% end %>
-                </ul>
-              </td>
-              <td><%= employer.message %></td>
-              <td><%= employer.created_at.strftime("%Y-%m-%d %H:%M %Z") %></td>
-            </tr>
-          <% end %>
-
-        </tbody>
-      </table>
     </div>
   </div>
 </div>

--- a/app/views/employer_prospects/index.html.erb
+++ b/app/views/employer_prospects/index.html.erb
@@ -1,0 +1,52 @@
+<div class="container-fluid">
+  <h2 class="text-center">Employer Prospects</h2>
+  <div class="table-responsive">
+    <table class="table table-hover table-condensed table-striped table-employer">
+      <thead class="thead-dark">
+        <tr>
+          <th scope="col">id</th>
+          <th scope="col">First Name</th>
+          <th scope="col">Last Name</th>
+          <th scope="col">Email</th>
+          <th scope="col">Phone Number</th>
+          <th scope="col">Company</th>
+          <th scope="col">Website</th>
+          <th scope="col">Targets</th>
+          <th scope="col">Locations</th>
+          <th scope="col">Message</th>
+          <th scope="col">Created At</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @employers.each do |employer| %>
+          <tr>
+            <th scope="row"><%= employer.id %></th>
+            <td><%= employer.first_name %></td>
+            <td><%= employer.last_name %></td>
+            <td><%= employer.email %></td>
+            <td><%= employer.phone_number %></td>
+            <td><%= employer.company %></td>
+            <td><%= employer.website %></td>
+            <td class="employer-table-list"><%# employer.targets.join(", ") %>
+              <ul class="list-unstyled">
+                <% employer.targets.each do |target| %>
+                  <li><%= target %></li>
+                <% end %>
+              </ul>
+            </td>
+            <td class="employer-table-list">
+              <ul class="list-unstyled">
+                <% employer.locations.each do |location| %>
+                  <li><%= location %></li>
+                <% end %>
+              </ul>
+            </td>
+            <td><%= employer.message %></td>
+            <td><%= employer.created_at.strftime("%Y-%m-%d %H:%M %Z") %></td>
+          </tr>
+        <% end %>
+
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/employer_prospects/index.html.erb
+++ b/app/views/employer_prospects/index.html.erb
@@ -1,6 +1,15 @@
 <div id="employer_prospects_index">
   <div class="container">
     <h2 class="text-center">Employer Prospects</h2>
+    <div class="employer-index-filter text-center">
+      <%= form_tag "/employer_prospects", method: "get", class: "form-inline" do %>
+        <div class="form-group">
+          <%= label_tag :city, "Filter by location:" %>
+          <%= select_tag :city, options_for_select(@cities.map {|city| [city.name, city.slug]}, params[:city]), class: "form-control" %>
+        </div>
+        <%= submit_tag "Search", class: "btn btn-default" %>
+      <% end %>
+    </div>
     <div class="row">
       <% @employers.each do |employer| %>
         <div class="col-xs-12">

--- a/app/views/layouts/back_office.html.erb
+++ b/app/views/layouts/back_office.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html >
+<head>
+  <title>Le Wagon - Back Office</title>
+  <meta charset="utf-8" />
+  <link rel="icon" href="<%= image_path 'favicon.png' %>" type="image/png" />
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <%= stylesheet_link_tag "application", media: "all" %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+  <%= yield %>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     delete '/log_out', to: 'base#log_out'
   end
 
-  resources :employer_prospects, only: [:create]
+  resources :employer_prospects, only: [:create, :index]
 
   resources :prospects, only: :create
 


### PR DESCRIPTION
Add a dedicated page to allow drivers to see the employer prospects message coming from the hiring form on `www`.

Very simple. With a dropdown filter to filter out by city.
Very basic auth.

Dedicated layout "back_office" (no navbar, no footer)

![screenshot-2018-2-12 le wagon - back office](https://user-images.githubusercontent.com/6984619/36101332-5633a780-1009-11e8-83b3-6513a10d2fef.png)


