### PR TITLE
Change old alumni url for newer one

### DIFF
--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -142,7 +142,7 @@
         <div class="col-xs-12 col-sm-offset-<%= (12 % slice.count) / 2 %>">
           <% slice.each do |ta| %>
             <div class="col-xs-6 col-sm-<%= 12 / slice.count %> ta-card">
-              <%= link_to "http://alumni.lewagon.org/#{ta.github_nickname}", target: :blank do %>
+              <%= link_to "https://kitt.lewagon.com/alumni/#{ta.github_nickname}", target: :blank do %>
                 <%= cl_adaptive_image_tag ta.official_avatar_url, width: 80, height: 80, crop: :fill, class: "img-circle" %>
               <% end %>
               <h4><%= ta.name %></h4>


### PR DESCRIPTION
The standalone Alumni platform is dead now. All TAs profile link on `www` cities page are dead.
This PR change old URL for new ones