### PR TITLE
Fix Slack notification for Syllabus and freetrack prospects

### DIFF
--- a/app/controllers/prospects_controller.rb
+++ b/app/controllers/prospects_controller.rb
@@ -3,7 +3,8 @@ class ProspectsController < ApplicationController
     @prospect = Prospect.find_or_create_by(
       email: params[:prospect][:email],
       from_path: params[:prospect][:from_path],
-      city: params[:prospect][:city])
+      city: params[:prospect][:city],
+      origin: "freetrack")
 
     if @prospect.valid?
       ProspectMailer.invite(@prospect.id).deliver_later

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -23,13 +23,23 @@ class Prospect < ApplicationRecord
   private
 
   def notify_slack
-    count_prospect_for_today = Prospect.where("created_at >= ?", Date.today).count
-    city_part = city.blank? ? nil : ", coming from *#{city.capitalize}*,"
     NotifySlack.perform_later({
       "channel": Rails.env.development? ? "test" : "incoming",
       "username": "www",
       "icon_url": "https://raw.githubusercontent.com/lewagon/mooc-images/master/slack_bot.png",
-      "text": "Today's #{count_prospect_for_today}#{count_prospect_for_today.ordinal} prospect#{city_part} for the free Web Development Basics track on *#{from_path}*: #{email}"
+      "text": origin == "syllabus" ? download_syllabus_notification_text : free_track_notification_text
     })
+  end
+
+  def download_syllabus_notification_text
+    count_prospect_for_today = Prospect.where("created_at >= ?", Date.today).where(origin: "syllabus").count
+    city_part = city.blank? ? nil : ", coming from *#{city.capitalize}*,"
+    "Today's #{count_prospect_for_today}#{count_prospect_for_today.ordinal} prospect#{city_part} who downloaded the *Syllabus* pdf: #{email}"
+  end
+
+  def free_track_notification_text
+    count_prospect_for_today = Prospect.where("created_at >= ?", Date.today).where(origin: "freetrack").count
+    city_part = city.blank? ? nil : ", coming from *#{city.capitalize}*,"
+    "Today's #{count_prospect_for_today}#{count_prospect_for_today.ordinal} prospect#{city_part} for the free Web Development Basics track on *#{from_path}*: #{email}"
   end
 end


### PR DESCRIPTION
- Flag Free Track prospect with "freetrack" label
- Adapt text thanks to origin column in Prospect

You can see some tests in slack #test channel

in the slack notification message, we are counting the prospects within its origin scope (syllabus, or freetrack)